### PR TITLE
replaced alerts with delegate method invocations

### DIFF
--- a/Classes/ios/RFduinoManagerDelegate.h
+++ b/Classes/ios/RFduinoManagerDelegate.h
@@ -39,5 +39,8 @@
 - (void)didConnectRFduino:(RFduino *)rfduino;
 - (void)didLoadServiceRFduino:(RFduino *)rfduino;
 - (void)didDisconnectRFduino:(RFduino *)rfduino;
+- (void)didFailToConnectWithError: (NSError *) error;
+- (void)peripheralDidDisconnectWithError: (NSError *) error;
+- (void)centralManagerDidEncounterErrorWithMessage: (NSString *) message andCode: (uint) errorCode;
 
 @end

--- a/Classes/ios/RfduinoManager.m
+++ b/Classes/ios/RfduinoManager.m
@@ -98,12 +98,9 @@ static CBUUID *service_uuid;
             
     }
     
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Bluetooth LE Support"
-                                                    message:message
-                                                   delegate:nil
-                                          cancelButtonTitle:@"OK"
-                                          otherButtonTitles:nil];
-    [alert show];
+    if ([delegate respondsToSelector:@selector(centralManagerDidEncounterErrorWithMessage:andCode:)]) {
+        [delegate centralManagerDidEncounterErrorWithMessage:message andCode:[central state]];
+    }
     
     return NO;
 }
@@ -189,12 +186,9 @@ static CBUUID *service_uuid;
     if (error.code) {
         cancelBlock = block;
         
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Peripheral Disconnected with Error"
-                                                        message:error.description
-                                                       delegate:self
-                                              cancelButtonTitle:@"OK"
-                                              otherButtonTitles:nil];
-        [alert show];
+        if ([delegate respondsToSelector:@selector(peripheralDidDisconnectWithError:)]) {
+            [delegate peripheralDidDisconnectWithError:error];
+        }
     }
     else
         block();
@@ -273,13 +267,9 @@ static CBUUID *service_uuid;
 - (void)centralManager:(CBCentralManager *)central didFailToConnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error
 {
     NSLog(@"didFailToConnectPeripheral");
-    
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Connect Failed"
-                                                    message:error.description
-                                                   delegate:nil
-                                          cancelButtonTitle:@"OK"
-                                          otherButtonTitles:nil];
-    [alert show];
+    if ([delegate respondsToSelector:@selector(didFailToConnectWithError:)]) {
+        [delegate didFailToConnectWithError:error];
+    }
 }
 
 - (void)centralManager:(CBCentralManager *)central didRetrieveConnectedPeripherals:(NSArray *)peripherals

--- a/RFduino-library.podspec
+++ b/RFduino-library.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RFduino-library"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "RFduino-library is a few classes to manage & communicate with RFduino boards over BlueTooth 4.0"
   s.description  = "This code provides an easy way to communicate with the RFduino boards. It originally came from https://github.com/RFduino/RFduino, but I have made a few minor changes."
   s.homepage     = "http://www.rfduino.com"


### PR DESCRIPTION
I am using this lib for one of my projects and wanted to have control over whether or not to show UIAlertViews based on error messages returned by the central manager. This pull request replaces these alerts with delegate method invocations so that you are in charge of what to do when these events occur.
